### PR TITLE
Added case for background-size

### DIFF
--- a/CSSMin.java
+++ b/CSSMin.java
@@ -494,6 +494,8 @@ class Part {
 	}
 	
 	private void simplifyParameters() {
+		if (this.property.equals("background-size")) return;
+		
 		StringBuffer newContents = new StringBuffer();
 		
 		String[] params = this.contents.split(" ");


### PR DESCRIPTION
The background-size property should not have its parameters simplified, as the 'simplified' version is not equivalent.
